### PR TITLE
feat: set quota project when using impersonation

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -229,7 +229,8 @@ public class BQConnection implements Connection {
                 connectTimeout,
                 rootUrl,
                 httpTransport,
-                targetServiceAccounts);
+                targetServiceAccounts,
+                this.getProjectId());
         this.logger.info("Authorized with service account");
       } catch (GeneralSecurityException e) {
         throw new BQSQLException(e);
@@ -246,7 +247,8 @@ public class BQConnection implements Connection {
                 readTimeout,
                 rootUrl,
                 httpTransport,
-                targetServiceAccounts);
+                targetServiceAccounts,
+                this.getProjectId());
         this.logger.info("Authorized with OAuth access token");
       } catch (SQLException e) {
         throw new BQSQLException(e);
@@ -260,7 +262,8 @@ public class BQConnection implements Connection {
                 readTimeout,
                 rootUrl,
                 httpTransport,
-                targetServiceAccounts);
+                targetServiceAccounts,
+                this.getProjectId());
       } catch (IOException e) {
         throw new BQSQLException(e);
       }

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -476,7 +476,7 @@ public class Oauth2Bigquery {
     return (PrivateKey) keystore.getKey(keystore.aliases().nextElement(), password.toCharArray());
   }
 
-  public static class HttpRequestTimeoutInitializer extends HttpCredentialsAdapter {
+  private static class HttpRequestTimeoutInitializer extends HttpCredentialsAdapter {
     private Integer readTimeout = null;
     private Integer connectTimeout = null;
 

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -269,7 +269,7 @@ public class JdbcUrlTest {
   }
 
   @Test
-  public void delegationsThowWithBadDelegationChain() throws IOException, SQLException {
+  public void delegationsThrowWithBadDelegationChain() throws IOException, SQLException {
     Properties testProps = getProperties("/applicationdefault.properties");
     String url =
         BQDriver.getURLPrefix()

--- a/src/test/resources/sampleaccount.properties
+++ b/src/test/resources/sampleaccount.properties
@@ -2,3 +2,4 @@ projectid=super-party-888
 type=service
 user=697117590302-76cr6q3217nck6gks0kf4r151j4d9f8e@developer.gserviceaccount.com
 password=src/test/resources/credentials_go_here.p12
+transformquery=true

--- a/src/test/resources/sampleaccount.properties
+++ b/src/test/resources/sampleaccount.properties
@@ -2,4 +2,3 @@ projectid=super-party-888
 type=service
 user=697117590302-76cr6q3217nck6gks0kf4r151j4d9f8e@developer.gserviceaccount.com
 password=src/test/resources/credentials_go_here.p12
-transformquery=true

--- a/src/test/resources/vpcaccount.properties
+++ b/src/test/resources/vpcaccount.properties
@@ -1,6 +1,7 @@
-projectid=super-party-888
+projectid=disco-parsec-659
 type=service
 user=697117590302-76cr6q3217nck6gks0kf4r151j4d9f8e@developer.gserviceaccount.com
-password=src/test/resources/bigquery_credentials.p12
 dataset=looker_test
+password=src/test/resources/bigquery_credentials.p12
 transformquery=true
+rootUrl=https://restricted.googleapis.com

--- a/src/test/resources/vpcaccount.properties
+++ b/src/test/resources/vpcaccount.properties
@@ -1,7 +1,5 @@
-projectid=disco-parsec-659
+projectid=super-party-888
 type=service
 user=697117590302-76cr6q3217nck6gks0kf4r151j4d9f8e@developer.gserviceaccount.com
-dataset=looker_test
 password=src/test/resources/bigquery_credentials.p12
 transformquery=true
-rootUrl=https://restricted.googleapis.com


### PR DESCRIPTION
When using SA impersonation we need to explicitly set a quota project that will be used for billing services. Here we add the `projectId` specified in the JDBC URL as the quota project when constructing the `ImpersonatedCredentials` to use. This effectively makes the `projectId` declared in the URL the billing project that will be used for all BQ jobs.