### PR TITLE
Upgrade GSON The package com.google.code.gson:gson before 2.8.9 are v…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.6</version>
+      <version>2.8.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade GSON The package com.google.code.gson:gson before 2.8.9 are vulnerable to Deserialization of Untrusted Data via the writeReplace() method in internal classes, which may lead to DoS attacks