### PR TITLE
Add Google Drive scope for OAuth2

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -287,8 +287,7 @@ public class Oauth2Bigquery {
       throws GeneralSecurityException, IOException {
     GoogleCredentials credential =
         createServiceAccountCredential(
-                serviceaccountemail, keypath, password, jsonAuthContents, false)
-            .createScoped(GenerateScopes(false));
+            serviceaccountemail, keypath, password, jsonAuthContents, false);
 
     logger.debug("Authorized?");
 
@@ -342,7 +341,6 @@ public class Oauth2Bigquery {
       throws IOException {
     GoogleCredentials credential =
         GoogleCredentials.getApplicationDefault().createScoped(GenerateScopes(false));
-    ;
 
     logger.debug("Authorizing with Application Default Credentials.");
 


### PR DESCRIPTION
* Add Google Drive scope to all locations where we create Google
Credentials.
* Changed the Drive scope to be read-only.