### PR TITLE
bump google-api-client from 1.32.1 -> 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.32.1</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>


### PR DESCRIPTION
An [auth bypass vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-22573) was found in `com.google.oauth-client:google-oauth-client` which is a dependency of `google-api-client`. Bumping `google-api-client` gets us `com.google.oauth-client:google-oauth-client:1.34.1` which does not have the CVE (previous version was `1.31.5`).