### PR TITLE
fix: NullPointException when statistics query is null

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -27,21 +27,22 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.Data;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.sql.*;
 import java.sql.Date;
+import java.sql.*;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class implements the java.sql.ResultSet interface, as a Forward only resultset
@@ -157,14 +158,14 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
       throw new BQSQLException("Failed to fetch results. Connection is closed.");
     }
     this.bigquery = bigquery;
-
-    if (completedJob != null) {
-      BiEngineStatistics biEngineStatistics =
-          completedJob.getStatistics().getQuery().getBiEngineStatistics();
-      if (biEngineStatistics != null) {
-        biEngineMode = biEngineStatistics.getBiEngineMode();
-        biEngineReasons = biEngineStatistics.getBiEngineReasons();
-      }
+    Optional<BiEngineStatistics> biEngineStatisticsOptional = Optional.ofNullable(completedJob)
+            .map(Job::getStatistics)
+            .map(JobStatistics::getQuery)
+            .map(JobStatistics2::getBiEngineStatistics);
+    if (biEngineStatisticsOptional.isPresent()){
+      BiEngineStatistics biEngineStatistics = biEngineStatisticsOptional.get();
+      biEngineMode = biEngineStatistics.getBiEngineMode();
+      biEngineReasons = biEngineStatistics.getBiEngineReasons();
     }
     this.biEngineMode = biEngineMode;
     this.biEngineReasons = biEngineReasons;

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -22,14 +22,7 @@
  */
 package net.starschema.clouddb.jdbc;
 
-import com.google.api.services.bigquery.model.BiEngineReason;
-import com.google.api.services.bigquery.model.BiEngineStatistics;
-import com.google.api.services.bigquery.model.Job;
-import com.google.api.services.bigquery.model.JobReference;
-import com.google.api.services.bigquery.model.JobStatistics2;
-import com.google.api.services.bigquery.model.QueryResponse;
-import com.google.api.services.bigquery.model.TableRow;
-import com.google.api.services.bigquery.model.TableSchema;
+import com.google.api.services.bigquery.model.*;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -38,6 +31,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -199,15 +193,14 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                   .setLocation(qr.getJobReference().getLocation())
                   .execute();
 
-          if (referencedJob != null) {
-            JobStatistics2 statistics2 = referencedJob.getStatistics().getQuery();
-            if (statistics2 != null) {
-              BiEngineStatistics biEngineStatistics = statistics2.getBiEngineStatistics();
-              if (biEngineStatistics != null) {
-                biEngineMode = biEngineStatistics.getBiEngineMode();
-                biEngineReasons = biEngineStatistics.getBiEngineReasons();
-              }
-            }
+          Optional<BiEngineStatistics> biEngineStatisticsOptional = Optional.ofNullable(referencedJob)
+                  .map(Job::getStatistics)
+                  .map(JobStatistics::getQuery)
+                  .map(JobStatistics2::getBiEngineStatistics);
+          if (biEngineStatisticsOptional.isPresent()){
+            BiEngineStatistics biEngineStatistics = biEngineStatisticsOptional.get();
+            biEngineMode = biEngineStatistics.getBiEngineMode();
+            biEngineReasons = biEngineStatistics.getBiEngineReasons();
           }
         }
       }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -22,22 +22,18 @@
  */
 package net.starschema.clouddb.jdbc;
 
-import com.google.api.services.bigquery.model.BiEngineReason;
-import com.google.api.services.bigquery.model.BiEngineStatistics;
-import com.google.api.services.bigquery.model.Job;
-import com.google.api.services.bigquery.model.JobReference;
-import com.google.api.services.bigquery.model.QueryResponse;
-import com.google.api.services.bigquery.model.TableRow;
-import com.google.api.services.bigquery.model.TableSchema;
+import com.google.api.services.bigquery.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class partially implements java.sql.Statement, and java.sql.PreparedStatement
@@ -349,13 +345,14 @@ public abstract class BQStatementRoot {
           String biEngineMode = null;
           List<BiEngineReason> biEngineReasons = null;
 
-          if (referencedJob != null) {
-            BiEngineStatistics biEngineStatistics =
-                referencedJob.getStatistics().getQuery().getBiEngineStatistics();
-            if (biEngineStatistics != null) {
-              biEngineMode = biEngineStatistics.getBiEngineMode();
-              biEngineReasons = biEngineStatistics.getBiEngineReasons();
-            }
+          Optional<BiEngineStatistics> biEngineStatisticsOptional = Optional.ofNullable(referencedJob)
+                  .map(Job::getStatistics)
+                  .map(JobStatistics::getQuery)
+                  .map(JobStatistics2::getBiEngineStatistics);
+          if (biEngineStatisticsOptional.isPresent()) {
+            BiEngineStatistics biEngineStatistics = biEngineStatisticsOptional.get();
+            biEngineMode = biEngineStatistics.getBiEngineMode();
+            biEngineReasons = biEngineStatistics.getBiEngineReasons();
           }
           return new BQScrollableResultSet(
               rows,


### PR DESCRIPTION
When I used bigquery, I found a null pointer exception. I learned that the project uses JDK8, so I used Optional to rewrite this part of the code to avoid this exception.