### PR TITLE
fix: NullPointException when statistics query is null

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -23,9 +23,6 @@
 package net.starschema.clouddb.jdbc;
 
 import com.google.api.services.bigquery.model.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.math.BigInteger;
 import java.sql.*;
@@ -34,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class partially implements java.sql.Statement, and java.sql.PreparedStatement
@@ -345,7 +344,8 @@ public abstract class BQStatementRoot {
           String biEngineMode = null;
           List<BiEngineReason> biEngineReasons = null;
 
-          Optional<BiEngineStatistics> biEngineStatisticsOptional = Optional.ofNullable(referencedJob)
+          Optional<BiEngineStatistics> biEngineStatisticsOptional =
+              Optional.ofNullable(referencedJob)
                   .map(Job::getStatistics)
                   .map(JobStatistics::getQuery)
                   .map(JobStatistics2::getBiEngineStatistics);

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -22,22 +22,18 @@
  */
 package net.starschema.clouddb.jdbc;
 
-import com.google.api.services.bigquery.model.BiEngineReason;
-import com.google.api.services.bigquery.model.BiEngineStatistics;
-import com.google.api.services.bigquery.model.Job;
-import com.google.api.services.bigquery.model.JobReference;
-import com.google.api.services.bigquery.model.QueryResponse;
-import com.google.api.services.bigquery.model.TableRow;
-import com.google.api.services.bigquery.model.TableSchema;
+import com.google.api.services.bigquery.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class partially implements java.sql.Statement, and java.sql.PreparedStatement
@@ -349,13 +345,14 @@ public abstract class BQStatementRoot {
           String biEngineMode = null;
           List<BiEngineReason> biEngineReasons = null;
 
-          if (referencedJob != null) {
-            BiEngineStatistics biEngineStatistics =
-                referencedJob.getStatistics().getQuery().getBiEngineStatistics();
-            if (biEngineStatistics != null) {
-              biEngineMode = biEngineStatistics.getBiEngineMode();
-              biEngineReasons = biEngineStatistics.getBiEngineReasons();
-            }
+          Optional<BiEngineStatistics> biEngineStatisticsOptional = Optional.ofNullable(referencedJob)
+                  .map(Job::getStatistics)
+                  .map(JobStatistics::getQuery)
+                  .map(JobStatistics2::getBiEngineStatistics);
+          if (biEngineStatisticsOptional.isPresent()) {
+            BiEngineStatistics biEngineStatistics = biEngineStatisticsOptional.get();
+            biEngineMode = biEngineStatistics.getBiEngineMode();
+            biEngineReasons = biEngineStatistics.getBiEngineReasons();
           }
           return new BQScrollableResultSet(
               rows,


### PR DESCRIPTION
Uses [Optional](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html) to make fetching BI Engine statistics null-safe.