### PR TITLE
Bump commons-io version from 1.3.2 to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.3.2</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>


### PR DESCRIPTION
    An [improper limited path
    traversal vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-29425) was found in
    commons-io:commons-io. Bumping the version from 1.3.2 to 2.11.0 gives a
    version without the CVE.