### PR TITLE
Update com.google.guava:guava dependency to v32.0.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-iamcredentials</artifactId>
-      <version>v1-rev20211203-1.32.1</version>
+      <version>v1-rev20211203-2.0.0</version>
     </dependency>
     <!-- START TEST DEPENDENCIES -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -111,16 +111,6 @@
       <artifactId>google-cloud-bigquery</artifactId>
       <version>2.29.0</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.42.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-iamcredentials</artifactId>
-      <version>v1-rev20211203-2.0.0</version>
-    </dependency>
     <!-- START TEST DEPENDENCIES -->
     <dependency>
       <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,11 +117,6 @@
       <version>1.42.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.0.1-jre</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-iamcredentials</artifactId>
       <version>v1-rev20211203-2.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,14 +107,9 @@
       <version>2.11.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.api-client</groupId>
-      <artifactId>google-api-client</artifactId>
-      <version>1.35.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auth</groupId>
-      <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.7.0</version>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigquery</artifactId>
+      <version>2.29.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
@@ -125,11 +120,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>32.0.1-jre</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-bigquery</artifactId>
-      <version>v2-rev20220611-1.32.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,11 @@
       <version>1.42.0</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.0.1-jre</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-bigquery</artifactId>
       <version>v2-rev20220611-1.32.1</version>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -23,7 +23,7 @@
 package net.starschema.clouddb.jdbc;
 
 import com.google.api.client.json.JsonGenerator;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.Data;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.model.BiEngineReason;
@@ -475,7 +475,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
   private String easyToJson(Object resultObject) throws SQLException {
     Writer writer = new StringWriter();
     try {
-      JsonGenerator gen = new JacksonFactory().createJsonGenerator(writer);
+      JsonGenerator gen = new GsonFactory().createJsonGenerator(writer);
       gen.serialize(resultObject);
       gen.close();
     } catch (IOException e) {

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -28,16 +28,13 @@ import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.Bigquery.Builder;
 import com.google.api.services.bigquery.BigqueryRequest;
 import com.google.api.services.bigquery.BigqueryRequestInitializer;
 import com.google.api.services.bigquery.BigqueryScopes;
 import com.google.api.services.bigquery.MinifiedBigquery;
-import com.google.api.services.iamcredentials.v1.IAMCredentials;
-import com.google.api.services.iamcredentials.v1.model.GenerateAccessTokenRequest;
-import com.google.api.services.iamcredentials.v1.model.GenerateAccessTokenResponse;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -53,7 +50,6 @@ import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -67,7 +63,7 @@ public class Oauth2Bigquery {
   static final HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
   /** Global instance of the JSON factory. */
-  private static final JsonFactory JSON_FACTORY = new JacksonFactory();
+  private static final JsonFactory JSON_FACTORY = new GsonFactory();
 
   /** Log4j logger, for debugging. */
   static Logger logger = LoggerFactory.getLogger(Oauth2Bigquery.class);
@@ -376,24 +372,8 @@ public class Oauth2Bigquery {
     GoogleCredentials credential =
         createServiceAccountCredential(
             serviceaccountemail, keypath, password, jsonAuthContents, true);
-    HttpRequestTimeoutInitializer httpRequestInitializer =
-        new HttpRequestTimeoutInitializer(credential);
 
-    IAMCredentials.Builder builder =
-        new IAMCredentials.Builder(HTTP_TRANSPORT, JSON_FACTORY, httpRequestInitializer)
-            .setApplicationName(applicationName);
-
-    IAMCredentials iamCredentials = builder.build();
-
-    String name = "projects/-/serviceAccounts/" + serviceaccountemail;
-    GenerateAccessTokenRequest request = new GenerateAccessTokenRequest();
-    request.setScope(Collections.singletonList(BigqueryScopes.CLOUD_PLATFORM));
-
-    IAMCredentials.Projects.ServiceAccounts.GenerateAccessToken generateAccessToken;
-    generateAccessToken =
-        iamCredentials.projects().serviceAccounts().generateAccessToken(name, request);
-    GenerateAccessTokenResponse response = generateAccessToken.execute();
-    return response.getAccessToken();
+    return credential.refreshAccessToken().getTokenValue();
   }
 
   /**


### PR DESCRIPTION
bqjdbc uses com.google.guava:guava as a transitive dependency. It needs to be bumped from 31.1-jre to 32.0.1-jre per
https://osv.dev/vulnerability/GHSA-7g45-4rm6-3mm3.

Also added the google-cloud-bigquery dependency, so that we don't have to pick out specific libraries from the Google Java client.

Since JacksonFactory is deprecated
https://cloud.google.com/java/docs/reference/google-http-client/latest/com.google.api.client.json.jackson2,
now using com.google.api.client.json.gson.GsonFactory instead.

Remove com.google.api.services.iamcredentials.v1 and now use Explicit
Credential Loading
https://github.com/googleapis/google-auth-library-java/blob/main/README.md#explicit-credential-loading
to generate an access token.