### PR TITLE
Update google-cloud-bigquery to 2.34.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
        to a groupId that we have ownership over -->
   <groupId>com.google.looker-open-source</groupId>
   <artifactId>bqjdbc</artifactId>
-  <version>2.3.27</version>
+  <version>2.3.28-SNAPSHOT</version>
   <name>Big Query over JDBC</name>
   <description>A simple JDBC driver, to reach Google's BigQuery</description>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>2.29.0</version>
+      <version>2.34.0</version>
     </dependency>
     <!-- START TEST DEPENDENCIES -->
     <dependency>


### PR DESCRIPTION
Update com.google.cloud:google-cloud-bigquery to 2.34.0. The 2.29.0 version of com.google.cloud:google-cloud-bigquery uses org.json:json version 20230618 as a transitive dependency, which has a vulnerability listed here: https://osv.dev/vulnerability/GHSA-rm7j-f5g5-27vv. 2.34.0 uses a newer version of org.json:json, 20231013.