### PR TITLE
Remove OAuth token from query params in API requests

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -646,6 +646,36 @@ public class BQSupportFuncts {
       Map<String, String> labels,
       boolean useQueryCache)
       throws IOException {
+    return getSyncQuery(
+            bigquery,
+            projectId,
+            querySql,
+            dataSet,
+            useLegacySql,
+            maxBillingBytes,
+            queryTimeoutMs,
+            maxResults,
+            labels,
+            useQueryCache)
+        .execute();
+  }
+
+  /*
+   * Gets a query as specified, but does not execute it.
+   * Introduced for assertions on the property of the query.
+   * */
+  static Bigquery.Jobs.Query getSyncQuery(
+      Bigquery bigquery,
+      String projectId,
+      String querySql,
+      String dataSet,
+      Boolean useLegacySql,
+      Long maxBillingBytes,
+      Long queryTimeoutMs,
+      Long maxResults,
+      Map<String, String> labels,
+      boolean useQueryCache)
+      throws IOException {
     QueryRequest qr =
         new QueryRequest()
             .setLabels(labels)
@@ -661,7 +691,7 @@ public class BQSupportFuncts {
       qr.setMaxResults(maxResults);
     }
 
-    return bigquery.jobs().query(projectId, qr).execute();
+    return bigquery.jobs().query(projectId, qr);
   }
 
   /**

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -119,9 +119,6 @@ public class Oauth2Bigquery {
       if (userAgent != null) {
         requestInitializer.setUserAgent(userAgent);
       }
-      if (oauthToken != null) {
-        requestInitializer.setOauthToken(oauthToken);
-      }
 
       bqBuilder.setBigqueryRequestInitializer(requestInitializer);
     }
@@ -506,18 +503,9 @@ public class Oauth2Bigquery {
   private static class BigQueryRequestUserAgentInitializer extends BigqueryRequestInitializer {
 
     String userAgent = null;
-    String oauthToken = null;
 
     public void setUserAgent(String userAgent) {
       this.userAgent = userAgent;
-    }
-
-    public void setOauthToken(String oauthToken) {
-      this.oauthToken = oauthToken;
-    }
-
-    public String getOauthToken() {
-      return this.oauthToken;
     }
 
     @Override
@@ -528,9 +516,6 @@ public class Oauth2Bigquery {
         currentHeaders.setUserAgent(userAgent);
 
         request.setRequestHeaders(currentHeaders);
-      }
-      if (oauthToken != null) {
-        request.setOauthToken(oauthToken);
       }
     }
   }

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -3,6 +3,7 @@ package net.starschema.clouddb.jdbc;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.api.services.bigquery.Bigquery.Jobs.Query;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -170,6 +171,39 @@ public class JdbcUrlTest {
 
     BQStatement stmt = new BQStatement(oauthProps.getProperty("projectid"), bqConn);
     stmt.executeQuery("SELECT * FROM orders limit 1");
+  }
+
+  @Test
+  public void oAuthAccessTokenOnlyInHeader()
+      throws SQLException, IOException, GeneralSecurityException {
+    // generate access token from service account credentials
+    Properties serviceProps = getProperties("/protectedaccount.properties");
+    String accessToken =
+        Oauth2Bigquery.generateAccessToken(
+            serviceProps.getProperty("user"),
+            serviceProps.getProperty("path"),
+            serviceProps.getProperty("password"),
+            null);
+
+    Properties oauthProps = getProperties("/oauthaccount.properties");
+    oauthProps.setProperty("oauthaccesstoken", accessToken);
+    String url = BQSupportFuncts.constructUrlFromPropertiesFile(oauthProps, true, null);
+    BQConnection bqConn = new BQConnection(url, new Properties());
+    BQStatement stmt = new BQStatement(oauthProps.getProperty("projectid"), bqConn);
+    Query query =
+        BQSupportFuncts.getSyncQuery(
+            bqConn.getBigquery(),
+            oauthProps.getProperty("projectid"),
+            "SELECT * FROM orders limit 1",
+            bqConn.getDataSet(),
+            bqConn.getUseLegacySql(),
+            null,
+            stmt.getSyncTimeoutMillis(),
+            (long) stmt.getMaxRows(),
+            stmt.getAllLabels(),
+            bqConn.getUseQueryCache());
+    String oAuthToken = query.getOauthToken();
+    Assert.assertTrue(oAuthToken == null);
   }
 
   @Test

--- a/src/test/java/net/starschema/clouddb/jdbc/PreparedStatementTests.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/PreparedStatementTests.java
@@ -75,9 +75,8 @@ public class PreparedStatementTests {
       PreparedStatementTests.con =
           DriverManager.getConnection(
               BQSupportFuncts.constructUrlFromPropertiesFile(
-                  BQSupportFuncts.readFromPropFile(
-                      "src/test/resources/installedaccount1.properties")),
-              BQSupportFuncts.readFromPropFile("src/test/resources/installedaccount1.properties"));
+                  BQSupportFuncts.readFromPropFile("installedaccount1.properties")),
+              BQSupportFuncts.readFromPropFile("installedaccount1.properties"));
     } catch (Exception e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
- we were redundantly setting the OAuth Token in query parameter via BigQueryRequestUserAgentInitializer#initializeBigqueryRequest.
- The HttpRequestTimeoutInitializer which builds the HttpRequest was already setting it in the header of the request, which is the accepted method.
- remove the call to setOauthToken and associated code which is no longer required.
- in service of http://b/294919784

this PR was reverted because we did not do a full integration test between Helltool and BigQuery OAuth with these changes, and we wanted to unblock other PRs. Now, I'm revisiting this issue