### PR TITLE
Use recommended semantics for getObject of date/time types

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -61,10 +61,6 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -126,9 +122,6 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
    * of the while(Result.next() == true) { } iterating method
    */
   private int Cursor = -1;
-
-  private final DateTimeFormatter TIMESTAMP_FORMATTER =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.of("UTC"));
 
   public BQForwardOnlyResultSet(
       Bigquery bigquery,
@@ -248,7 +241,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
    */
   public Object getObject(int columnIndex) throws SQLException {
 
-    String result = getString(columnIndex, false);
+    String result = rawString(columnIndex);
 
     if (this.wasNull()) {
       return null;
@@ -274,16 +267,26 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
       if (Columntype.equals("INTEGER")) {
         return toLong(result);
       }
+      if (Columntype.equals("DATETIME")) {
+        // A BigQuery DATETIME is essentially defined by its string representation;
+        // the "clock-calendar parameters" comprising year, month, day, hour, minute, etc.
+        // On the other hand, a [java.sql.Timestamp] object is defined as a global instant, similar
+        // to BQ TIMESTAMP. It has a [toString] method that interprets that instant in the system
+        // default time zone. Thus, in order to produce a [Timestamp] object whose [toString] method
+        // has the correct result, we must adjust the value of the instant according to the system
+        // default time zone (passing a null Calendar uses the system default).
+        return DateTimeUtils.parseDateTime(result, null);
+      }
       if (Columntype.equals("TIMESTAMP")) {
-        return toTimestamp(result, null);
+        // A BigQuery TIMESTAMP is defined as a global instant in time, so when we create the
+        // [java.sql.Timestamp] object to represent it, we must not make any time zone adjustment.
+        return DateTimeUtils.parseTimestamp(result);
       }
       if (Columntype.equals("DATE")) {
-        return toDate(result, null);
+        return DateTimeUtils.parseDate(result, null);
       }
-      if (Columntype.equals("DATETIME")) {
-        // Date time represents a "clock face" time and so should NOT be processed into an actual
-        // time
-        return result;
+      if (Columntype.equals("TIME")) {
+        return DateTimeUtils.parseTime(result, null);
       }
       if (Columntype.equals("NUMERIC")) {
         return toBigDecimal(result);
@@ -321,69 +324,11 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     }
   }
 
-  /** Parse date/time types */
-  private Timestamp toTimestamp(String value, Calendar cal) throws SQLException {
-    try {
-      long dbValue =
-          new BigDecimal(value)
-              .movePointRight(3)
-              .longValue(); // movePointRight(3) =  *1000 (done before rounding) - from seconds
-      // (BigQuery specifications) to milliseconds (required by java).
-      // Precision under millisecond is discarded (BigQuery supports
-      // micro-seconds)
-      if (cal == null) {
-        cal =
-            Calendar.getInstance(
-                TimeZone.getTimeZone(
-                    "UTC")); // The time zone of the server that host the JVM should NOT impact the
-        // results. Use UTC calendar instead (which wont apply any correction,
-        // whatever the time zone of the data)
-      }
-
-      Calendar dbCal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-      dbCal.setTimeInMillis(dbValue);
-      cal.set(Calendar.YEAR, dbCal.get(Calendar.YEAR));
-      cal.set(Calendar.MONTH, dbCal.get(Calendar.MONTH));
-      cal.set(Calendar.DAY_OF_MONTH, dbCal.get(Calendar.DAY_OF_MONTH));
-      cal.set(Calendar.HOUR_OF_DAY, dbCal.get(Calendar.HOUR_OF_DAY));
-      cal.set(Calendar.MINUTE, dbCal.get(Calendar.MINUTE));
-      cal.set(Calendar.SECOND, dbCal.get(Calendar.SECOND));
-      cal.set(Calendar.MILLISECOND, dbCal.get(Calendar.MILLISECOND));
-      return new Timestamp(cal.getTime().getTime());
-    } catch (NumberFormatException e) {
-      // before giving up, check to see if we've been given a 'time' value without a
-      // date, e.g. from current_time(), and if we have, try to parse it
-      try {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        String dateStringFromValue = ("1970-01-01 " + value).substring(0, 19);
-        java.util.Date parsedDate = dateFormat.parse(dateStringFromValue);
-        return new java.sql.Timestamp(parsedDate.getTime());
-      } catch (Exception e2) {
-        throw new BQSQLException(e);
-      }
-    }
-  }
-
   // Secondary converters
 
   /** Parse integral or floating types with (virtually) infinite precision */
   private BigDecimal toBigDecimal(String value) {
     return new BigDecimal(value);
-  }
-
-  static Date toDate(String value, Calendar cal) throws SQLException {
-    // Dates in BigQuery come back in the YYYY-MM-DD format
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-    try {
-      java.util.Date date = sdf.parse(value);
-      return new java.sql.Date(date.getTime());
-    } catch (java.text.ParseException e) {
-      throw new BQSQLException(e);
-    }
-  }
-
-  private Time toTime(String value, Calendar cal) throws SQLException {
-    return new java.sql.Time(toTimestamp(value, cal).getTime());
   }
 
   @Override
@@ -396,10 +341,18 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
    *     is unsupported
    */
   public String getString(int columnIndex) throws SQLException {
-    return getString(columnIndex, true);
+    String rawString = rawString(columnIndex);
+
+    BQResultsetMetaData metadata = getBQResultsetMetaData();
+    if (metadata.getColumnTypeName(columnIndex).equals("TIMESTAMP")
+        && !metadata.getColumnMode(columnIndex).equals("REPEATED")) {
+      return DateTimeUtils.formatTimestamp(rawString);
+    }
+
+    return rawString;
   }
 
-  private String getString(int columnIndex, boolean formatTimestamps) throws SQLException {
+  private String rawString(int columnIndex) throws SQLException {
     // to make the logfiles smaller!
     // logger.debug("Function call getString columnIndex is: " + String.valueOf(columnIndex));
     this.closestrm();
@@ -410,21 +363,21 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
       throw new BQSQLException("ColumnIndex is not valid");
     }
 
-    if (this.rowsofResult == null) throw new BQSQLException("Invalid position!");
+    if (this.rowsofResult == null) {
+      throw new BQSQLException("Invalid position!");
+    }
+
+    // Since the results came from BigQuery's JSON API,
+    // the only types we'll ever see for resultObject are JSON-supported types,
+    // i.e. strings, numbers, arrays, booleans, or null.
+    // Many standard Java types, like timestamps, will be represented as strings.
     Object resultObject = this.rowsofResult.get(this.Cursor).getF().get(columnIndex - 1).getV();
+
     if (Data.isNull(resultObject)) {
       this.wasnull = true;
       return null;
     }
     this.wasnull = false;
-    if (!this.getBQResultsetMetaData().getColumnMode(columnIndex).equals("REPEATED")
-        && formatTimestamps
-        && getMetaData().getColumnTypeName(columnIndex).equals("TIMESTAMP")) {
-      Instant instant =
-          Instant.ofEpochMilli(
-              (new BigDecimal((String) resultObject).movePointRight(3)).longValue());
-      return TIMESTAMP_FORMATTER.format(instant);
-    }
     if (resultObject instanceof List || resultObject instanceof Map) {
       Object resultTransformedWithSchema =
           smartTransformResult(resultObject, schema.getFields().get(columnIndex - 1));
@@ -913,11 +866,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
   /** {@inheritDoc} */
   @Override
   public Date getDate(int columnIndex) throws SQLException {
-    String value = this.getString(columnIndex);
-    if (this.wasNull()) {
-      return null;
-    }
-    return toDate(value, null);
+    return getDate(columnIndex, null);
   }
 
   /** {@inheritDoc} */
@@ -927,14 +876,13 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     if (this.wasNull()) {
       return null;
     }
-    return toDate(value, cal);
+    return DateTimeUtils.parseDate(value, cal);
   }
 
   /** {@inheritDoc} */
   @Override
   public Date getDate(String columnLabel) throws SQLException {
-    int columnIndex = this.findColumn(columnLabel);
-    return this.getDate(columnIndex);
+    return getDate(columnLabel, null);
   }
 
   /** {@inheritDoc} */
@@ -1336,11 +1284,7 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
   /** {@inheritDoc} */
   @Override
   public Time getTime(int columnIndex) throws SQLException {
-    String value = this.getString(columnIndex);
-    if (this.wasNull()) {
-      return null;
-    }
-    return toTime(value, null);
+    return getTime(columnIndex, null);
   }
 
   /** {@inheritDoc} */
@@ -1350,14 +1294,13 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     if (this.wasNull()) {
       return null;
     }
-    return toTime(value, cal);
+    return DateTimeUtils.parseTime(value, cal);
   }
 
   /** {@inheritDoc} */
   @Override
   public Time getTime(String columnLabel) throws SQLException {
-    int columnIndex = this.findColumn(columnLabel);
-    return this.getTime(columnIndex);
+    return getTime(columnLabel, null);
   }
 
   /** {@inheritDoc} */
@@ -1370,28 +1313,29 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
   /** {@inheritDoc} */
   @Override
   public Timestamp getTimestamp(int columnIndex) throws SQLException {
-    String value = this.getString(columnIndex);
-    if (this.wasNull()) {
-      return null;
-    }
-    return toTimestamp(value, null);
+    return getTimestamp(columnIndex, null);
   }
 
   /** {@inheritDoc} */
   @Override
   public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
-    String value = this.getString(columnIndex);
+    String value = rawString(columnIndex);
     if (this.wasNull()) {
       return null;
     }
-    return toTimestamp(value, cal);
+    // Both the TIMESTAMP and DATETIME objects support JDBC's getTimestamp method.
+    // DATETIME in BigQuery is analogous to TIMESTAMP in ISO SQL.
+    // TIMESTAMP in BigQuery is analogous to TIMESTAMP WITH LOCAL TIME ZONE in ISO SQL.
+    String columnType = this.schema.getFields().get(columnIndex - 1).getType();
+    return "TIMESTAMP".equals(columnType)
+        ? DateTimeUtils.parseTimestamp(value)
+        : DateTimeUtils.parseDateTime(value, cal);
   }
 
   /** {@inheritDoc} */
   @Override
   public Timestamp getTimestamp(String columnLabel) throws SQLException {
-    int columnIndex = this.findColumn(columnLabel);
-    return this.getTimestamp(columnIndex);
+    return getTimestamp(columnLabel, null);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/net/starschema/clouddb/jdbc/DateTimeUtils.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/DateTimeUtils.java
@@ -1,0 +1,156 @@
+package net.starschema.clouddb.jdbc;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+class DateTimeUtils {
+
+  private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+  private static final Calendar DEFAULT_CALENDAR = new GregorianCalendar(TimeZone.getDefault());
+
+  /** Formatter used to parse DATETIME literals. */
+  private static final DateTimeFormatter DATETIME_FORMATTER =
+      new DateTimeFormatterBuilder()
+          // The date part is always YYYY-MM-DD.
+          .appendValue(ChronoField.YEAR, 4)
+          .appendLiteral('-')
+          .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+          .appendLiteral('-')
+          .appendValue(ChronoField.DAY_OF_MONTH, 2)
+          // Accept either a literal 'T' or a space to separate the date from the time.
+          // Make the space optional but pad with 'T' if it's omitted, so that parsing accepts both,
+          // but formatting defaults to using the space.
+          .padNext(1, 'T')
+          .optionalStart()
+          .appendLiteral(' ')
+          .optionalEnd()
+          // The whole-second time part is always HH:MM:SS.
+          .appendValue(ChronoField.HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+          .appendLiteral(':')
+          .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+          // BigQuery has optional microsecond precision.
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
+          .optionalEnd()
+          .toFormatter(Locale.ROOT);
+
+  /** Formatter used to parse TIME literals. */
+  private static final DateTimeFormatter TIME_FORMATTER =
+      new DateTimeFormatterBuilder()
+          // The whole-second time part is always HH:MM:SS.
+          .appendValue(ChronoField.HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+          .appendLiteral(':')
+          .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+          // BigQuery only has microsecond precision, but this parser supports up to nanosecond
+          // precision after the decimal point.
+          .optionalStart()
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+          .optionalEnd()
+          .toFormatter(Locale.ROOT);
+
+  private static final LocalDate TIME_EPOCH = LocalDate.of(1970, 1, 1);
+
+  /** Parse a BigQuery DATETIME represented as a String. */
+  static Timestamp parseDateTime(String value, Calendar cal) throws SQLException {
+    if (cal == null) {
+      cal = DEFAULT_CALENDAR;
+    }
+    try {
+      // BigQuery DATETIME has a string representation that looks like e.g. "2010-10-26 02:49:35".
+      LocalDateTime localDateTime = LocalDateTime.parse(value, DATETIME_FORMATTER);
+      // In order to represent it as a [java.sql.Timestamp], which is defined by an instant,
+      // we must subtract the offset from the calendar, so that the [toString] method of the
+      // resulting [Timestamp] has the correct result. Since time zones can have different offsets
+      // at different times of year (e.g. due to Daylight Saving), first calculate the instant
+      // assuming no offset, and use that to calculate the offset.
+      long utcInstant = localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+      ZoneOffset offset = ZoneOffset.ofTotalSeconds(cal.getTimeZone().getOffset(utcInstant) / 1000);
+      Instant instant = localDateTime.atOffset(offset).toInstant();
+      Timestamp timestamp = new Timestamp(instant.toEpochMilli());
+      timestamp.setNanos(instant.getNano());
+      return timestamp;
+    } catch (DateTimeParseException e) {
+      throw new BQSQLException(e);
+    }
+  }
+
+  /** Parse a BigQuery TIMESTAMP literal, represented as the number of seconds since epoch. */
+  static Timestamp parseTimestamp(String value) throws SQLException {
+    try {
+      // BigQuery TIMESTAMP has a string representation that looks like e.g. "1.288061375E9"
+      // for 2010-10-26 02:49:35 UTC.
+      // It is the (possibly fractional) number of seconds since the epoch.
+      BigDecimal secondsSinceEpoch = new BigDecimal(value);
+      // https://stackoverflow.com/questions/5839411/java-sql-timestamp-way-of-storing-nanoseconds
+      // In order to support sub-millisecond precision, we need to first initialize the timestamp
+      // with the correct number of whole seconds (expressed in milliseconds),
+      // then set the nanosecond value, which overrides the initial milliseconds.
+      long wholeSeconds = secondsSinceEpoch.longValue();
+      Timestamp timestamp = new Timestamp(wholeSeconds * 1000L);
+      int nanoSeconds = secondsSinceEpoch.remainder(BigDecimal.ONE).movePointRight(9).intValue();
+      timestamp.setNanos(nanoSeconds);
+      return timestamp;
+    } catch (NumberFormatException e) {
+      throw new BQSQLException(e);
+    }
+  }
+
+  static String formatTimestamp(String rawString) throws SQLException {
+    Timestamp timestamp = parseTimestamp(rawString);
+    return DATETIME_FORMATTER.format(OffsetDateTime.ofInstant(timestamp.toInstant(), UTC_ZONE))
+        + " UTC";
+  }
+
+  static Date parseDate(String value, Calendar cal) throws SQLException {
+    // Dates in BigQuery come back in the YYYY-MM-DD format
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+    try {
+      java.util.Date date = sdf.parse(value);
+      return new java.sql.Date(date.getTime());
+    } catch (java.text.ParseException e) {
+      throw new BQSQLException(e);
+    }
+  }
+
+  static Time parseTime(String value, Calendar cal) throws SQLException {
+    if (cal == null) {
+      cal = DEFAULT_CALENDAR;
+    }
+    try {
+      // BigQuery DATETIME has a string representation that looks like e.g. "2010-10-26 02:49:35".
+      LocalTime localTime = LocalTime.parse(value, TIME_FORMATTER);
+      // In order to represent it as a [java.sql.Time], which is defined by an instant,
+      // we must subtract the offset from the calendar, so that the [toString] method of the
+      // resulting [Time] has the correct result. Since time values do not have date components,
+      // assume the standard offset should be used.
+      ZoneOffset offset = ZoneOffset.ofTotalSeconds(cal.getTimeZone().getRawOffset() / 1000);
+      Instant instant = localTime.atDate(TIME_EPOCH).atOffset(offset).toInstant();
+      return new Time(instant.toEpochMilli());
+    } catch (DateTimeParseException e) {
+      throw new BQSQLException(e);
+    }
+  }
+}


### PR DESCRIPTION
This change affects the way BigQuery's `TIME`, `TIMESTAMP`, and `DATETIME` types are handled in result sets.

- Adds support for microsecond precision in `getObject()`, `getString()`, and `getTimestamp()` for all types.
- `getObject()` will return a `java.sql.Timestamp` object for `TIMESTAMP` and `DATETIME`. Previously, it returned `String` for `DATETIME`.
- `getObject()` will return a `java.sql.Time` object for `TIME`. Previously, it threw an error.