### PR TITLE
Bump commons-io:commons-io from 2.11 to 2.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
+      <version>2.15.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
A more aggressive bump than
https://github.com/looker-open-source/bqjdbc/pull/196

Also tests will run against this because it's a branch on the main repo