### PR TITLE
Prepare for v3.2.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
        to a groupId that we have ownership over -->
   <groupId>com.google.looker-open-source</groupId>
   <artifactId>bqjdbc</artifactId>
-  <version>3.1.1</version>
+  <version>3.2.0</version>
   <name>Big Query over JDBC</name>
   <description>A simple JDBC driver, to reach Google's BigQuery</description>
   <properties>


### PR DESCRIPTION
This CL bumps the minor version of the BQJDBC driver. In a recently merged PR[0], we added the ability to configure a default dataset project id, which is used in conjunction with the dataset id to locate unqualified table references. We added this new capability in a backwards compatible manner.

[0] https://github.com/looker-open-source/bqjdbc/pull/201