### PR TITLE
Fix stale syncResponse state in overloaded executeQuery

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -152,6 +152,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
       return executeQueryHelper(querySql, unlimitedBillingBytes);
     } finally {
       this.job = null;
+      this.syncResponseFromCurrentQuery.set(null);
       this.connection.removeRunningStatement(this);
     }
   }


### PR DESCRIPTION
If a query takes longer than 5 seconds (the sync query timeout), the driver leaves the statement in a state indicating the query is not done (jobComplete = false) inside the syncResponseFromCurrentQuery reference.

The standard executeQuery(String) method correctly cleans up this state in its finally block. However, the overloaded method executeQuery(String, boolean) used for unlimited billing queries omitted this cleanup.

Consequently, when Looker later calls close() (which invokes cancel()), the driver incorrectly thinks the query is still running and attempts to cancel it. This cancel request fails with a 400 Bad Request (if the query already finished) or a 403 Forbidden (if using restricted OAuth scopes), causing query results to be overwritten by a fatal "Failed to kill query" exception.

This change adds `this.syncResponseFromCurrentQuery.set(null);` to the finally block of the overloaded executeQuery(String, boolean) method, aligning it with the standard execution path and preventing erroneous cancellation attempts.

Bug: b/522228414, b/523362913